### PR TITLE
Route refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
+        "react-router-dom": "^6.22.3",
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
@@ -2431,6 +2432,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.0",
@@ -5381,6 +5390,36 @@
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
+      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
+    "react-router-dom": "^6.22.3",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function AppRouter() {
   // Update height when component first mounts
   useEffect(() => {
     updateHeight();
-    
+
     // Also update height on route changes
     const handleRouteChange = () => {
       // Use requestAnimationFrame to wait for render
@@ -24,10 +24,10 @@ function AppRouter() {
     };
 
     // Listen for route changes
-    window.addEventListener('popstate', handleRouteChange);
-    
+    window.addEventListener("popstate", handleRouteChange);
+
     return () => {
-      window.removeEventListener('popstate', handleRouteChange);
+      window.removeEventListener("popstate", handleRouteChange);
     };
   }, [updateHeight]);
 
@@ -36,18 +36,27 @@ function AppRouter() {
       <Routes>
         {/* Default route redirects to federal table */}
         <Route path="/" element={<Navigate to="/federal/table" replace />} />
-        
+
         {/* Federal routes */}
         <Route path="/federal/table" element={<FederalTableView />} />
-        <Route path="/federal/scorecard/:bioguideId/:congress" element={<FederalScorecardView />} />
-        
+        <Route
+          path="/federal/scorecard/:bioguideId/:congress"
+          element={<FederalScorecardView />}
+        />
+
         {/* State routes */}
         <Route path="/state/table" element={<StateTableView />} />
-        <Route path="/state/scorecard/:state/:slesId/:term" element={<StateScorecardView />} />
-        
+        <Route
+          path="/state/scorecard/:state/:slesId/:term"
+          element={<StateScorecardView />}
+        />
+
         {/* Performance view */}
-        <Route path="/performance/:bioguideId/:congress" element={<PerformanceView />} />
-        
+        <Route
+          path="/performance/:bioguideId/:congress"
+          element={<PerformanceView />}
+        />
+
         {/* Fallback route */}
         <Route path="*" element={<Navigate to="/federal/table" replace />} />
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,20 +40,20 @@ function AppRouter() {
         {/* Federal routes */}
         <Route path="/federal/table" element={<FederalTableView />} />
         <Route
-          path="/federal/scorecard/:bioguideId/:congress"
+          path="/federal/scorecard/:bioguideId"
           element={<FederalScorecardView />}
         />
 
         {/* State routes */}
         <Route path="/state/table" element={<StateTableView />} />
         <Route
-          path="/state/scorecard/:state/:slesId/:term"
+          path="/state/scorecard/:state/:slesId"
           element={<StateScorecardView />}
         />
 
         {/* Performance view */}
         <Route
-          path="/performance/:bioguideId/:congress"
+          path="/performance/:bioguideId"
           element={<PerformanceView />}
         />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,77 +1,57 @@
 import { FederalScorecardView } from "@/components/federal/FederalScorecardView";
 import FederalTableView from "@/components/federal/FederalTableView";
-import type { ViewRoute } from "@/lib/types";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import PerformanceView from "./components/performance/PerformanceView";
 import { StateScorecardView } from "./components/state/StateScorecardView";
 import StateTableView from "./components/state/StateTableView";
 import { TableStateProvider, useTableState } from "./context/TableStateContext";
-
-const defaultRoute = { type: "federal:table" } as ViewRoute;
-// const defaultRoute = {
-//   type: "perf",
-//   bioguideID: "P000197",
-//   congress: 118,
-// } as ViewRoute;
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 
 // Create a router that handles height updates on route changes
 function AppRouter() {
-  const [route, setRoute] = useState<ViewRoute>(defaultRoute);
   const { updateHeight } = useTableState();
 
-  // Handle route changes with height updates
-  const handleRouteChange = useCallback(
-    (newRoute: ViewRoute) => {
-      setRoute(newRoute);
+  // Update height when component first mounts
+  useEffect(() => {
+    updateHeight();
+    
+    // Also update height on route changes
+    const handleRouteChange = () => {
       // Use requestAnimationFrame to wait for render
       requestAnimationFrame(() => {
         updateHeight();
       });
-    },
-    [updateHeight]
-  );
+    };
 
-  // Also update height when component first mounts
-  useEffect(() => {
-    updateHeight();
+    // Listen for route changes
+    window.addEventListener('popstate', handleRouteChange);
+    
+    return () => {
+      window.removeEventListener('popstate', handleRouteChange);
+    };
   }, [updateHeight]);
 
   return (
-    <>
-      {(() => {
-        switch (route.type) {
-          case "federal:table":
-            return (
-              <FederalTableView route={route} setRoute={handleRouteChange} />
-            );
-          case "federal:scorecard":
-            return (
-              <FederalScorecardView
-                legislator={route.legislator}
-                onBack={() => handleRouteChange({ type: "federal:table" })}
-              />
-            );
-          case "state:table":
-            return (
-              <StateTableView route={route} setRoute={handleRouteChange} />
-            );
-          case "state:scorecard":
-            return (
-              <StateScorecardView
-                legislator={route.legislator}
-                onBack={() => handleRouteChange({ type: "state:table" })}
-              />
-            );
-          case "perf":
-            return (
-              <PerformanceView
-                bioguideID={route.bioguideID}
-                congress={route.congress}
-              />
-            );
-        }
-      })()}
-    </>
+    <BrowserRouter>
+      <Routes>
+        {/* Default route redirects to federal table */}
+        <Route path="/" element={<Navigate to="/federal/table" replace />} />
+        
+        {/* Federal routes */}
+        <Route path="/federal/table" element={<FederalTableView />} />
+        <Route path="/federal/scorecard/:bioguideId/:congress" element={<FederalScorecardView />} />
+        
+        {/* State routes */}
+        <Route path="/state/table" element={<StateTableView />} />
+        <Route path="/state/scorecard/:state/:slesId/:term" element={<StateScorecardView />} />
+        
+        {/* Performance view */}
+        <Route path="/performance/:bioguideId/:congress" element={<PerformanceView />} />
+        
+        {/* Fallback route */}
+        <Route path="*" element={<Navigate to="/federal/table" replace />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/src/components/federal/FederalScorecardView.tsx
+++ b/src/components/federal/FederalScorecardView.tsx
@@ -12,12 +12,19 @@ import { ScoreMatrix } from "@/components/shared/ScoreMatrix";
 import { CongressSelector } from "@/components/federal/CongressSelector";
 import { FederalScorecardGlossary } from "@/components/federal/FederalScorecardGlossary";
 import { IssueCarousel } from "@/components/federal/IssueCarousel";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 export function FederalScorecardView() {
   const navigate = useNavigate();
-  const { bioguideId, congress: congressParam } = useParams();
-  const [selectedIssue, setSelectedIssue] = useState<string>("overall");
+  const { bioguideId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  
+  // Get congress and issue from URL query parameters
+  const congressParam = searchParams.get("congress");
+  const issueParam = searchParams.get("issue");
+  const [selectedIssue, setSelectedIssue] = useState<string>(
+    issueParam || "overall"
+  );
   const [selectedCongress, setSelectedCongress] = useState<number>(
     congressParam ? parseInt(congressParam) : 0
   );
@@ -76,6 +83,22 @@ export function FederalScorecardView() {
     }
   }, [scorecard]);
 
+  // Update URL when selected issue or congress changes
+  useEffect(() => {
+    if (selectedIssue && selectedCongress) {
+      const params = new URLSearchParams(searchParams);
+      params.set("congress", selectedCongress.toString());
+      
+      if (selectedIssue !== "overall") {
+        params.set("issue", selectedIssue);
+      } else {
+        params.delete("issue");
+      }
+      
+      setSearchParams(params, { replace: true });
+    }
+  }, [selectedIssue, selectedCongress, searchParams, setSearchParams]);
+
   // Scroll to selected issue whenever it changes or when congress changes
   useEffect(() => {
     if (issueListRef.current && selectedIssue !== "overall") {
@@ -93,8 +116,8 @@ export function FederalScorecardView() {
     
     setIsLoading(true);
     try {
-      // Update URL to reflect the new congress
-      navigate(`/federal/scorecard/${bioguideId}/${congress}`, { replace: true });
+      // Update selected congress state - URL will be updated by the effect
+      setSelectedCongress(congress);
       
       // Fetch new table data for the selected congress
       const tableData = await getTableData(congress);
@@ -109,7 +132,6 @@ export function FederalScorecardView() {
       // Fetch new scorecard data
       const newScorecard = await getScorecardData(congress, bioguideId);
 
-      setSelectedCongress(congress);
       setLegislator(newLegislator);
       setScorecard(newScorecard);
 

--- a/src/components/federal/FederalScorecardView.tsx
+++ b/src/components/federal/FederalScorecardView.tsx
@@ -12,43 +12,63 @@ import { ScoreMatrix } from "@/components/shared/ScoreMatrix";
 import { CongressSelector } from "@/components/federal/CongressSelector";
 import { FederalScorecardGlossary } from "@/components/federal/FederalScorecardGlossary";
 import { IssueCarousel } from "@/components/federal/IssueCarousel";
+import { useNavigate, useParams } from "react-router-dom";
 
-interface FederalScorecardProps {
-  legislator: VisTable;
-  onBack: () => void;
-}
-
-export function FederalScorecardView({
-  legislator: initialLegislator,
-  onBack,
-}: FederalScorecardProps) {
+export function FederalScorecardView() {
+  const navigate = useNavigate();
+  const { bioguideId, congress: congressParam } = useParams();
   const [selectedIssue, setSelectedIssue] = useState<string>("overall");
   const [selectedCongress, setSelectedCongress] = useState<number>(
-    initialLegislator.congress
+    congressParam ? parseInt(congressParam) : 0
   );
   const [matrixHeight, setMatrixHeight] = useState<number>(0);
   const matrixRef = useRef<HTMLDivElement>(null);
   const issueListRef = useRef<HTMLDivElement>(null);
-  const [legislator, setLegislator] = useState<VisTable>(initialLegislator);
+  const [legislator, setLegislator] = useState<VisTable | null>(null);
   const [scorecard, setScorecard] = useState<VisScorecardResponse | null>(null);
-  const [_, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
+  // Load legislator data on initial render
   useEffect(() => {
-    const fetchInitialScorecard = async () => {
+    if (!bioguideId || !congressParam) {
+      toast.error("Missing required parameters");
+      navigate("/federal/table");
+      return;
+    }
+
+    const fetchInitialData = async () => {
+      setIsLoading(true);
       try {
-        const newScorecard = await getScorecardData(
-          legislator.congress,
-          legislator.bioguide
+        // Fetch table data to get legislator info
+        const tableData = await getTableData(parseInt(congressParam));
+        const legislatorData = tableData.data.find(
+          (l) => l.bioguide === bioguideId
         );
+
+        if (!legislatorData) {
+          throw new Error("Legislator not found");
+        }
+
+        // Fetch scorecard data
+        const newScorecard = await getScorecardData(
+          parseInt(congressParam),
+          bioguideId
+        );
+
+        setLegislator(legislatorData);
         setScorecard(newScorecard);
+        setSelectedCongress(parseInt(congressParam));
       } catch (err) {
-        console.error("Failed to fetch initial scorecard data:", err);
-        toast.error("Failed to load scorecard");
+        console.error("Failed to fetch initial data:", err);
+        toast.error("Failed to load legislator data");
+        navigate("/federal/table");
+      } finally {
+        setIsLoading(false);
       }
     };
 
-    fetchInitialScorecard();
-  }, [legislator]);
+    fetchInitialData();
+  }, [bioguideId, congressParam, navigate]);
 
   useEffect(() => {
     if (matrixRef.current) {
@@ -69,12 +89,17 @@ export function FederalScorecardView({
   }, [selectedIssue, selectedCongress]);
 
   const handleCongressChange = async (congress: number) => {
+    if (!bioguideId) return;
+    
     setIsLoading(true);
     try {
+      // Update URL to reflect the new congress
+      navigate(`/federal/scorecard/${bioguideId}/${congress}`, { replace: true });
+      
       // Fetch new table data for the selected congress
       const tableData = await getTableData(congress);
       const newLegislator = tableData.data.find(
-        (l) => l.bioguide === initialLegislator.bioguide
+        (l) => l.bioguide === bioguideId
       );
 
       if (!newLegislator) {
@@ -82,10 +107,7 @@ export function FederalScorecardView({
       }
 
       // Fetch new scorecard data
-      const newScorecard = await getScorecardData(
-        congress,
-        initialLegislator.bioguide
-      );
+      const newScorecard = await getScorecardData(congress, bioguideId);
 
       setSelectedCongress(congress);
       setLegislator(newLegislator);
@@ -94,6 +116,7 @@ export function FederalScorecardView({
       // Only reset to overall if the selected issue doesn't exist in the new congress
       if (
         selectedIssue !== "overall" &&
+        newLegislator.iles && 
         !(selectedIssue.toLowerCase() in newLegislator.iles)
       ) {
         setSelectedIssue("overall");
@@ -105,6 +128,11 @@ export function FederalScorecardView({
       setIsLoading(false);
     }
   };
+
+  // Show loading state
+  if (isLoading || !legislator) {
+    return <div className="p-8">Loading legislator data...</div>;
+  }
 
   const locationText = getFederalLocationText(
     legislator.chamber,
@@ -121,7 +149,7 @@ export function FederalScorecardView({
 
   return (
     <div className="space-y-6">
-      <BackButton onClick={onBack} />
+      <BackButton onClick={() => navigate("/federal/table")} />
       <div className="grid grid-areas-scorecard-mobile md:grid-areas-scorecard gap-6">
         {/* Legislator Info and Issue Selection - Left column on desktop, top on mobile */}
         <div className="space-y-6 grid-in-scorecard-info">
@@ -205,7 +233,7 @@ export function FederalScorecardView({
           </Card>
         )}
 
-        {/* Glossary - Bottom on both desktop and mobile */}
+        {/* Glossary - Bottom on both layouts */}
         <div className="grid-in-scorecard-glossary">
           <FederalScorecardGlossary />
         </div>

--- a/src/components/federal/FederalTable.tsx
+++ b/src/components/federal/FederalTable.tsx
@@ -168,7 +168,6 @@ export function FederalTable({
         {
           name: "Party", // Party is not sortable now
           width: "w-[8%]",
-          // Removed sortField, currentSort, direction, onSort
         },
         {
           name: "State",

--- a/src/components/federal/FederalTableView.tsx
+++ b/src/components/federal/FederalTableView.tsx
@@ -4,15 +4,72 @@ import { FederalTableGlossary } from "@/components/federal/FederalTableGlossary"
 import { BaseTableView } from "@/components/shared/BaseTableView";
 import { LevelToggle } from "@/components/shared/LevelToggle";
 import { useFederalState } from "@/hooks/useFederalState";
-import { ViewRoute } from "@/lib/types";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useEffect } from "react";
 
-type FederalTableViewProps = {
-  route: ViewRoute;
-  setRoute: (route: ViewRoute) => void;
-};
-
-function FederalTableView({ setRoute }: FederalTableViewProps) {
+function FederalTableView() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const federalState = useFederalState();
+
+  // Sync URL parameters with state
+  useEffect(() => {
+    // Get parameters from URL if they exist
+    const congressParam = searchParams.get("congress");
+    const chamberParam = searchParams.get("chamber");
+    const stateParam = searchParams.get("state");
+    const issueParam = searchParams.get("issue");
+    const searchParam = searchParams.get("search");
+
+    // Update state from URL parameters if they exist
+    if (congressParam && !isNaN(Number(congressParam))) {
+      federalState.handleCongressChange(congressParam);
+    }
+    if (chamberParam && (chamberParam === "house" || chamberParam === "senate")) {
+      federalState.setChamber(chamberParam);
+    }
+    if (stateParam) {
+      federalState.setStateFilter(stateParam);
+    }
+    if (issueParam) {
+      federalState.setSelectedIssue(issueParam);
+    }
+    if (searchParam) {
+      federalState.setSearchTerm(searchParam);
+    }
+  }, []); // Only run once on component mount
+
+  // Update URL parameters when state changes
+  useEffect(() => {
+    const params = new URLSearchParams();
+    
+    // Only add parameters that have values
+    if (federalState.congress) {
+      params.set("congress", federalState.congress.toString());
+    }
+    if (federalState.chamber) {
+      params.set("chamber", federalState.chamber);
+    }
+    if (federalState.stateFilter) {
+      params.set("state", federalState.stateFilter);
+    }
+    if (federalState.selectedIssue) {
+      params.set("issue", federalState.selectedIssue);
+    }
+    if (federalState.searchTerm) {
+      params.set("search", federalState.searchTerm);
+    }
+    
+    // Update URL without causing a navigation
+    setSearchParams(params, { replace: true });
+  }, [
+    federalState.congress,
+    federalState.chamber,
+    federalState.stateFilter,
+    federalState.selectedIssue,
+    federalState.searchTerm,
+    setSearchParams
+  ]);
 
   return (
     <BaseTableView
@@ -20,9 +77,7 @@ function FederalTableView({ setRoute }: FederalTableViewProps) {
         <LevelToggle
           level="federal"
           onLevelChange={(newLevel) =>
-            setRoute({
-              type: newLevel === "state" ? "state:table" : "federal:table",
-            })
+            navigate(newLevel === "state" ? "/state/table" : "/federal/table")
           }
         />
       }
@@ -48,7 +103,7 @@ function FederalTableView({ setRoute }: FederalTableViewProps) {
           searchTerm={federalState.searchTerm}
           selectedIssue={federalState.selectedIssue}
           onLegislatorSelect={(legislator) =>
-            setRoute({ type: "federal:scorecard", legislator })
+            navigate(`/federal/scorecard/${legislator.bioguide}/${federalState.congress}`)
           }
         />
       }

--- a/src/components/federal/FederalTableView.tsx
+++ b/src/components/federal/FederalTableView.tsx
@@ -102,9 +102,21 @@ function FederalTableView() {
           stateFilter={federalState.stateFilter}
           searchTerm={federalState.searchTerm}
           selectedIssue={federalState.selectedIssue}
-          onLegislatorSelect={(legislator) =>
-            navigate(`/federal/scorecard/${legislator.bioguide}/${federalState.congress}`)
-          }
+          onLegislatorSelect={(legislator) => {
+            // Build the URL with query parameters
+            const url = new URL(`/federal/scorecard/${legislator.bioguide}`, window.location.origin);
+            
+            // Add congress parameter
+            url.searchParams.set('congress', federalState.congress.toString());
+            
+            // Add issue parameter if it's not 'all'
+            if (federalState.selectedIssue && federalState.selectedIssue !== 'all') {
+              url.searchParams.set('issue', federalState.selectedIssue);
+            }
+            
+            navigate(url.pathname + url.search);
+          }}
+          
         />
       }
       glossary={<FederalTableGlossary />}

--- a/src/components/performance/PerformanceView.tsx
+++ b/src/components/performance/PerformanceView.tsx
@@ -3,11 +3,7 @@ import { sortAscending } from "@/services/api.utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import PerformanceBar from "./PerformanceBar";
 import { Expectation } from "@/lib/expectations";
-
-interface Props {
-  bioguideID: string;
-  congress: number;
-}
+import { useParams, useNavigate } from "react-router-dom";
 
 type PerformanceData = {
   congress: number;
@@ -47,13 +43,13 @@ function calculateBarData(
   // Normalize values if in normalized mode
   let normalizedScore = score;
   let normalizedBenchmark = benchmark;
-  
+
   if (displayMode === "normalized") {
     // In normalized mode, benchmark becomes 1.0, and score is relative to benchmark
     normalizedScore = score / benchmark;
     normalizedBenchmark = 1.0;
   }
-  
+
   // Derive exceeds and below thresholds from benchmark
   const exceeds = normalizedBenchmark * 1.5;
   const below = normalizedBenchmark * 0.5;
@@ -138,7 +134,7 @@ function PerformanceBarLabels({
   const formatValue = (value: number) => {
     return value.toFixed(3);
   };
-  
+
   // Get the display values based on mode
   const getDisplayValue = (value: number) => {
     if (displayMode === "absolute") {
@@ -148,7 +144,7 @@ function PerformanceBarLabels({
       return `${(value * 100).toFixed(1)}%`;
     }
   };
-  
+
   // Get the actual score to display
   const displayScore = displayMode === "absolute" ? score : score / benchmark;
 
@@ -196,7 +192,10 @@ function PerformanceBarLabels({
   // Calculate text widths (approximate)
   const scoreTextWidth = getDisplayValue(displayScore).length * 6;
   const exceedsTextWidth = `Exceeds (${getDisplayValue(exceeds)})`.length * 6;
-  const benchmarkTextWidth = `Benchmark (${getDisplayValue(displayMode === "absolute" ? benchmark : 1.0)})`.length * 6;
+  const benchmarkTextWidth =
+    `Benchmark (${getDisplayValue(
+      displayMode === "absolute" ? benchmark : 1.0
+    )})`.length * 6;
   const belowTextWidth = `Below (${getDisplayValue(below)})`.length * 6;
 
   return (
@@ -261,8 +260,7 @@ function PerformanceBarLabels({
         <path
           d={`M ${plotX + plotWidth} ${exceedsY} 
               H ${
-                (plotX + plotWidth + (plotX + plotWidth + labelRightOffset)) /
-                2
+                (plotX + plotWidth + (plotX + plotWidth + labelRightOffset)) / 2
               } 
               V ${labelPositions.exceeds + labelHeight / 2} 
               H ${plotX + plotWidth + labelRightOffset}`}
@@ -290,15 +288,15 @@ function PerformanceBarLabels({
           fontSize="10"
           fill="#2563eb"
         >
-          Benchmark ({getDisplayValue(displayMode === "absolute" ? benchmark : 1.0)})
+          Benchmark (
+          {getDisplayValue(displayMode === "absolute" ? benchmark : 1.0)})
         </text>
 
         {/* Connector line from benchmark bar to label */}
         <path
           d={`M ${plotX + plotWidth} ${benchmarkY} 
               H ${
-                (plotX + plotWidth + (plotX + plotWidth + labelRightOffset)) /
-                2
+                (plotX + plotWidth + (plotX + plotWidth + labelRightOffset)) / 2
               } 
               V ${labelPositions.benchmark + labelHeight / 2} 
               H ${plotX + plotWidth + labelRightOffset}`}
@@ -333,8 +331,7 @@ function PerformanceBarLabels({
         <path
           d={`M ${plotX + plotWidth} ${belowY} 
               H ${
-                (plotX + plotWidth + (plotX + plotWidth + labelRightOffset)) /
-                2
+                (plotX + plotWidth + (plotX + plotWidth + labelRightOffset)) / 2
               } 
               V ${labelPositions.below + labelHeight / 2} 
               H ${plotX + plotWidth + labelRightOffset}`}
@@ -347,16 +344,26 @@ function PerformanceBarLabels({
   );
 }
 
-function PerformanceView({ bioguideID, congress }: Props) {
+function PerformanceView() {
+  const { bioguideId, congress: congressParam } = useParams();
+  const navigate = useNavigate();
   const [data, setData] = useState<PerformanceData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [displayMode, setDisplayMode] = useState<ScoreDisplayMode>("absolute");
 
+  // Validate route parameters
+  useEffect(() => {
+    if (!bioguideId || !congressParam) {
+      console.error("Missing route parameters:", { bioguideId, congressParam });
+      navigate("/federal/table");
+    }
+  }, [bioguideId, congressParam, navigate]);
+
   // TODO: single endpoint to get all this data
   const getPerformanceData = useCallback(
-    (bioguideID: string) =>
-      getScorecardData(congress, bioguideID)
+    (bioguideId: string) =>
+      getScorecardData(Number(congressParam), bioguideId)
         .then(({ data: { validCongresses } }) => validCongresses)
         .then((congresses) =>
           Promise.all(congresses.map(([congress]) => getTableData(congress)))
@@ -364,7 +371,7 @@ function PerformanceView({ bioguideID, congress }: Props) {
         .then((tables) =>
           tables
             .map((t) => {
-              const legislator = t.data.find((l) => l.bioguide === bioguideID);
+              const legislator = t.data.find((l) => l.bioguide === bioguideId);
               return legislator
                 ? {
                     congress: t.congress,
@@ -377,17 +384,22 @@ function PerformanceView({ bioguideID, congress }: Props) {
             .filter(notNull)
         )
         .then((data) => sortAscending(data, (d) => d.congress)),
-    [congress]
+    [congressParam]
   );
 
   useEffect(() => {
+    if (!bioguideId) return;
+
     setIsLoading(true);
-    getPerformanceData(bioguideID)
+    getPerformanceData(bioguideId)
       .then(setData)
+      .catch((error) => {
+        console.error("Error fetching performance data:", error);
+      })
       .finally(() => {
         setIsLoading(false);
       });
-  }, [bioguideID, getPerformanceData]);
+  }, [bioguideId, getPerformanceData]);
 
   // Calculate global min/max range for all bars
   const globalRange = useMemo(() => {
@@ -397,20 +409,20 @@ function PerformanceView({ bioguideID, congress }: Props) {
     // that includes 0.5 (below), 1.0 (benchmark), and 1.5 (exceeds)
     if (displayMode === "normalized") {
       // Get all normalized scores
-      const normalizedScores = data.map(d => d.score / d.benchmark);
-      
+      const normalizedScores = data.map((d) => d.score / d.benchmark);
+
       // Find min and max of normalized scores
       const min = Math.min(...normalizedScores, 0.5); // Include below threshold
       const max = Math.max(...normalizedScores, 1.5); // Include exceeds threshold
-      
+
       // Add margin
       const range = max - min;
       const margin = range * 0.2;
-      
+
       // Ensure we always include at least 0.5 to 1.5 range
       return [
         Math.max(0, Math.min(min - margin, 0.4)), // Never go below 0, try to include below threshold
-        Math.max(max + margin, 1.6) // Always include exceeds threshold with margin
+        Math.max(max + margin, 1.6), // Always include exceeds threshold with margin
       ] as [number, number];
     } else {
       // Absolute mode - use actual values
@@ -456,7 +468,7 @@ function PerformanceView({ bioguideID, congress }: Props) {
   return (
     <div className="flex flex-col">
       <div className="flex justify-between items-center mb-4">
-        <div>{bioguideID}</div>
+        <div>{bioguideId}</div>
         <button
           onClick={toggleDisplayMode}
           className="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300"
@@ -474,7 +486,7 @@ function PerformanceView({ bioguideID, congress }: Props) {
         <g>
           {data.map((d, index) => {
             const xPosition = leftMargin + index * (barWidth + spacing);
-            
+
             // Pre-calculate all the bar data
             const barData = calculateBarData(
               d.score,
@@ -486,15 +498,18 @@ function PerformanceView({ bioguideID, congress }: Props) {
               barHeight,
               displayMode
             );
-            
+
             // Set opacity based on hover state
             const isCurrentlyHovered = hoveredIndex === index;
-            const opacity = hoveredIndex === null || isCurrentlyHovered ? 1 : 0.2;
-            
+            const opacity =
+              hoveredIndex === null || isCurrentlyHovered ? 1 : 0.2;
+
             return (
               <g key={d.congress} opacity={opacity}>
                 <PerformanceBar
-                  score={displayMode === "absolute" ? d.score : d.score / d.benchmark}
+                  score={
+                    displayMode === "absolute" ? d.score : d.score / d.benchmark
+                  }
                   benchmark={displayMode === "absolute" ? d.benchmark : 1.0}
                   range={globalRange}
                   x={xPosition}
@@ -545,8 +560,8 @@ function PerformanceView({ bioguideID, congress }: Props) {
   );
 }
 
-export default function WithCongressList(props: Props) {
-  return <PerformanceView {...props} />;
+export default function WithCongressList() {
+  return <PerformanceView />;
 }
 
 function notNull<T>(value: T | null): value is T {

--- a/src/components/performance/PerformanceView.tsx
+++ b/src/components/performance/PerformanceView.tsx
@@ -3,7 +3,7 @@ import { sortAscending } from "@/services/api.utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import PerformanceBar from "./PerformanceBar";
 import { Expectation } from "@/lib/expectations";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 
 type PerformanceData = {
   congress: number;
@@ -345,7 +345,9 @@ function PerformanceBarLabels({
 }
 
 function PerformanceView() {
-  const { bioguideId, congress: congressParam } = useParams();
+  const { bioguideId } = useParams();
+  const [searchParams] = useSearchParams();
+  const congressParam = searchParams.get("congress");
   const navigate = useNavigate();
   const [data, setData] = useState<PerformanceData[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/src/components/state/StateScorecardView.tsx
+++ b/src/components/state/StateScorecardView.tsx
@@ -25,11 +25,13 @@ import { PartyLabel } from "@/components/shared/PartyLabel";
 import { ScoreMatrix } from "@/components/shared/ScoreMatrix";
 import { StateScorecardGlossary } from "@/components/state/StateScorecardGlossary";
 import { Term } from "@/lib/types";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 export function StateScorecardView() {
   const navigate = useNavigate();
-  const { state, slesId, term: termParam } = useParams();
+  const { state, slesId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const termParam = searchParams.get("term");
   const [selectedTerm, setSelectedTerm] = useState<Term | null>(null);
   const [legislator, setLegislator] = useState<StateVisTable | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -114,8 +116,10 @@ export function StateScorecardView() {
     const { startYear, endYear } = term;
     
     try {
-      // Update URL to reflect the new term
-      navigate(`/state/scorecard/${state}/${slesId}/${startYear}-${endYear}`, { replace: true });
+      // Update URL to reflect the new term using query parameters
+      const params = new URLSearchParams(searchParams);
+      params.set('term', `${startYear}-${endYear}`);
+      setSearchParams(params, { replace: true });
       
       // Fetch new table data first to get updated LES and rank
       const tableData = await getStateTableData(

--- a/src/components/state/StateScorecardView.tsx
+++ b/src/components/state/StateScorecardView.tsx
@@ -25,64 +25,105 @@ import { PartyLabel } from "@/components/shared/PartyLabel";
 import { ScoreMatrix } from "@/components/shared/ScoreMatrix";
 import { StateScorecardGlossary } from "@/components/state/StateScorecardGlossary";
 import { Term } from "@/lib/types";
+import { useNavigate, useParams } from "react-router-dom";
 
-interface StateScorecardProps {
-  legislator: StateVisTable;
-  onBack: () => void;
-}
-
-export function StateScorecardView({
-  legislator: initialLegislator,
-  onBack,
-}: StateScorecardProps) {
-  const [selectedTerm, setSelectedTerm] = useState<Term>(
-    initialLegislator.term
-  );
-  const [legislator, setLegislator] =
-    useState<StateVisTable>(initialLegislator);
-  const [isLoading, setIsLoading] = useState(false);
+export function StateScorecardView() {
+  const navigate = useNavigate();
+  const { state, slesId, term: termParam } = useParams();
+  const [selectedTerm, setSelectedTerm] = useState<Term | null>(null);
+  const [legislator, setLegislator] = useState<StateVisTable | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [scorecard, setScorecard] = useState<StateVisScorecardResponse | null>(
     null
   );
 
+  // Load initial data when component mounts
   useEffect(() => {
-    const fetchInitialScorecard = async () => {
+    if (!state || !slesId || !termParam) {
+      toast.error("Missing required parameters");
+      navigate("/state/table");
+      return;
+    }
+
+    const fetchInitialData = async () => {
       try {
-        const newScorecard = await getStateScorecardData(
-          legislator.slesId,
-          legislator.term.startYear,
-          legislator.term.endYear
+        // Parse term from URL parameter (format: "2023-2024")
+        const [startYear, endYear] = termParam.split("-").map(Number);
+        
+        if (isNaN(startYear) || isNaN(endYear)) {
+          throw new Error("Invalid term format");
+        }
+
+        // Fetch table data with the state we already know from the URL
+        const tableData = await getStateTableData(
+          state!,
+          startYear,
+          endYear
         );
+
+        const legislatorData = tableData.data.find(
+          (l) => l.slesId === parseInt(slesId!)
+        );
+
+        if (!legislatorData) {
+          throw new Error("Legislator not found");
+        }
+
+        // We already have the legislator data from the first API call
+        const updatedLegislator = legislatorData;
+        
+        // No need for a second check since we already found the legislator
+
+        // Fetch scorecard data
+        const newScorecard = await getStateScorecardData(
+          parseInt(slesId),
+          startYear,
+          endYear
+        );
+
+        setSelectedTerm({ startYear, endYear });
+        setLegislator(updatedLegislator);
         setScorecard(newScorecard);
       } catch (err) {
-        console.error("failed to fetch initials corecard data:", err);
-        toast.error("Failed to load scorecard");
+        console.error("Failed to fetch initial data:", err);
+        toast.error("Failed to load legislator data");
+        navigate("/state/table");
+      } finally {
+        setIsLoading(false);
       }
     };
 
-    fetchInitialScorecard();
-  }, [legislator]);
+    fetchInitialData();
+  }, [slesId, termParam, navigate]);
 
   const handleTermChange = async (termString: string) => {
+    if (!legislator || !scorecard || !slesId) return;
+    
     setIsLoading(true);
 
-    const term = scorecard?.validStateTerms.find(
+    const term = scorecard.validStateTerms.find(
       (term) => getTermDisplayName(term) === termString
     );
+    
     if (!term) {
       toast.error("Invalid term selected");
       setIsLoading(false);
       return;
     }
+    
     const { startYear, endYear } = term;
+    
     try {
-      // TODO: Add endpoint that supports atomic return for term + lesId rather than filtering response on this side
+      // Update URL to reflect the new term
+      navigate(`/state/scorecard/${state}/${slesId}/${startYear}-${endYear}`, { replace: true });
+      
       // Fetch new table data first to get updated LES and rank
       const tableData = await getStateTableData(
-        legislator.state,
+        state!, // Use the state from URL params instead of legislator.state
         startYear,
         endYear
       );
+      
       const updatedLegislator = tableData.data.find(
         (l) => l.slesId === legislator.slesId
       );
@@ -94,7 +135,7 @@ export function StateScorecardView({
 
       // Then fetch new scorecard data
       const newScorecard = await getStateScorecardData(
-        legislator.slesId,
+        parseInt(slesId),
         startYear,
         endYear
       );
@@ -111,6 +152,11 @@ export function StateScorecardView({
     }
   };
 
+  // Show loading state
+  if (isLoading || !legislator || !selectedTerm) {
+    return <div className="p-8">Loading legislator data...</div>;
+  }
+
   // Location text
   const locationText = getStateLocationText(legislator.district);
 
@@ -120,7 +166,7 @@ export function StateScorecardView({
 
   return (
     <div className="space-y-6">
-      <BackButton onClick={onBack} />
+      <BackButton onClick={() => navigate("/state/table")} />
       <div className="grid grid-areas-scorecard-mobile md:grid-areas-scorecard gap-6">
         {/* Legislator Info and Term Selection - Left column on desktop, top on mobile */}
         <div className="space-y-6 grid-in-scorecard-info">

--- a/src/components/state/StateTableView.tsx
+++ b/src/components/state/StateTableView.tsx
@@ -39,18 +39,21 @@ function StateTableView() {
   useEffect(() => {
     const params = new URLSearchParams();
     
-    // Only add parameters that have values
+    // Only add parameters if a state is selected
     if (stateState.selectedState) {
+      // Add the state parameter
       params.set("state", stateState.selectedState);
-    }
-    if (stateState.selectedTerm) {
-      params.set("term", stateState.selectedTerm);
-    }
-    if (stateState.stateChamber) {
-      params.set("chamber", stateState.stateChamber);
-    }
-    if (stateState.stateSearchTerm) {
-      params.set("search", stateState.stateSearchTerm);
+      
+      // Only add other parameters when a state is selected
+      if (stateState.selectedTerm) {
+        params.set("term", stateState.selectedTerm);
+      }
+      if (stateState.stateChamber) {
+        params.set("chamber", stateState.stateChamber);
+      }
+      if (stateState.stateSearchTerm) {
+        params.set("search", stateState.stateSearchTerm);
+      }
     }
     
     // Update URL without causing a navigation
@@ -90,9 +93,18 @@ function StateTableView() {
           selectedTerm={stateState.selectedTerm}
           chamber={stateState.stateChamber}
           searchTerm={stateState.stateSearchTerm}
-          onLegislatorSelect={(legislator) =>
-            navigate(`/state/scorecard/${stateState.selectedState}/${legislator.slesId}/${stateState.selectedTerm}`)
-          }
+          onLegislatorSelect={(legislator) => {
+            // Build the URL with query parameters
+            const url = new URL(`/state/scorecard/${stateState.selectedState}/${legislator.slesId}`, window.location.origin);
+            
+            // Add term parameter
+            if (stateState.selectedTerm) {
+              url.searchParams.set('term', stateState.selectedTerm);
+            }
+            
+            navigate(url.pathname + url.search);
+          }}
+          
         />
       }
       glossary={<StateTableGlossary />}

--- a/src/components/state/StateTableView.tsx
+++ b/src/components/state/StateTableView.tsx
@@ -4,15 +4,64 @@ import { StateTableGlossary } from "@/components/state/StateTableGlossary";
 import { StateTable } from "@/components/state/StateTable";
 import { BaseTableView } from "@/components/shared/BaseTableView";
 import { useStateState } from "@/hooks/useStateState";
-import { ViewRoute } from "@/lib/types";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useEffect } from "react";
 
-type StateTableViewProps = {
-  route: ViewRoute;
-  setRoute: (route: ViewRoute) => void;
-};
-
-function StateTableView({ setRoute }: StateTableViewProps) {
+function StateTableView() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const stateState = useStateState();
+
+  // Sync URL parameters with state
+  useEffect(() => {
+    // Get parameters from URL if they exist
+    const stateParam = searchParams.get("state");
+    const termParam = searchParams.get("term");
+    const chamberParam = searchParams.get("chamber");
+    const searchParam = searchParams.get("search");
+
+    // Update state from URL parameters if they exist
+    if (stateParam) {
+      stateState.setSelectedState(stateParam);
+    }
+    if (termParam) {
+      stateState.setSelectedTerm(termParam);
+    }
+    if (chamberParam && (chamberParam === "upper" || chamberParam === "lower")) {
+      stateState.setStateChamber(chamberParam);
+    }
+    if (searchParam) {
+      stateState.setStateSearchTerm(searchParam);
+    }
+  }, []); // Only run once on component mount
+
+  // Update URL parameters when state changes
+  useEffect(() => {
+    const params = new URLSearchParams();
+    
+    // Only add parameters that have values
+    if (stateState.selectedState) {
+      params.set("state", stateState.selectedState);
+    }
+    if (stateState.selectedTerm) {
+      params.set("term", stateState.selectedTerm);
+    }
+    if (stateState.stateChamber) {
+      params.set("chamber", stateState.stateChamber);
+    }
+    if (stateState.stateSearchTerm) {
+      params.set("search", stateState.stateSearchTerm);
+    }
+    
+    // Update URL without causing a navigation
+    setSearchParams(params, { replace: true });
+  }, [
+    stateState.selectedState,
+    stateState.selectedTerm,
+    stateState.stateChamber,
+    stateState.stateSearchTerm,
+    setSearchParams
+  ]);
 
   return (
     <BaseTableView
@@ -20,9 +69,7 @@ function StateTableView({ setRoute }: StateTableViewProps) {
         <LevelToggle
           level="state"
           onLevelChange={(newLevel) =>
-            setRoute({
-              type: newLevel === "federal" ? "federal:table" : "state:table",
-            })
+            navigate(newLevel === "federal" ? "/federal/table" : "/state/table")
           }
         />
       }
@@ -44,11 +91,7 @@ function StateTableView({ setRoute }: StateTableViewProps) {
           chamber={stateState.stateChamber}
           searchTerm={stateState.stateSearchTerm}
           onLegislatorSelect={(legislator) =>
-            setRoute({
-              type: "state:scorecard",
-              legislator,
-              term: stateState.selectedTerm,
-            })
+            navigate(`/state/scorecard/${stateState.selectedState}/${legislator.slesId}/${stateState.selectedTerm}`)
           }
         />
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   return {
-    base: env.VITE_BASE_PATH || "/cel-vis/",
+    base: mode === "development" ? "/" : env.VITE_BASE_PATH || "/cel-vis/",
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
Migrate onto query and path param routing system, away from in-data approach to view swapping and navigation.

Working for both federal and state, for both table and scorecard views.

Distinction between path and query params-- If data can be toggled by a user within federal or state view, it is a query param. If data constitutes a route on which query params are toggle, it is a path param.

E.g., `/federal/scorecard/${bioguide}?congress=${congress}&issue=${issue}`

Where, in a federal scorecard view, `bioguide` is a path param, while `congress` and `issue` are query params.

Branch also adds routing support to the experimental `/performance` page.